### PR TITLE
Tickets/dm 37479 2

### DIFF
--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -2,7 +2,7 @@
 Version History
 ===============
 
-v0.8.3
+v0.9.0
 ------
 
 * Adapt the **ts_tcpip** v1.0.0:

--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -2,6 +2,14 @@
 Version History
 ===============
 
+v0.8.3
+------
+
+* Adapt the **ts_tcpip** v1.0.0:
+
+  * Use the **LOCALHOST_IPV4** instead of **LOCAL_HOST**.
+  * Put the ``MockServer._connect_state_changed_callback_command()`` and ``MockServer._connect_state_changed_callback_telemetry()`` to be asynchronous.
+
 v0.8.2
 ------
 

--- a/python/lsst/ts/m2com/controller_cell.py
+++ b/python/lsst/ts/m2com/controller_cell.py
@@ -22,7 +22,7 @@
 import asyncio
 import time
 
-from lsst.ts.tcpip import LOCAL_HOST
+from lsst.ts.tcpip import LOCALHOST_IPV4
 from lsst.ts.utils import index_generator, make_done_future
 
 from . import Controller, MockServer, is_coroutine
@@ -141,7 +141,7 @@ class ControllerCell(Controller):
 
         # Run a new mock server
         self.mock_server = MockServer(
-            LOCAL_HOST,
+            LOCALHOST_IPV4,
             port_command=0,
             port_telemetry=0,
             log=self.log,

--- a/tests/mock/test_mock_server.py
+++ b/tests/mock/test_mock_server.py
@@ -56,7 +56,7 @@ class TestMockServer(unittest.IsolatedAsyncioTestCase):
     @classmethod
     def setUpClass(cls):
         cls.config_dir = get_config_dir()
-        cls.host = tcpip.LOCAL_HOST
+        cls.host = tcpip.LOCALHOST_IPV4
         cls.log = logging.getLogger()
         cls.maxsize_queue = 1000
 

--- a/tests/mock/test_mock_server_eui.py
+++ b/tests/mock/test_mock_server_eui.py
@@ -43,7 +43,7 @@ class TestMockServerEui(unittest.IsolatedAsyncioTestCase):
     @classmethod
     def setUpClass(cls):
         cls.config_dir = get_config_dir()
-        cls.host = tcpip.LOCAL_HOST
+        cls.host = tcpip.LOCALHOST_IPV4
         cls.log = logging.getLogger()
         cls.maxsize_queue = 1000
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -48,7 +48,7 @@ class TestController(unittest.IsolatedAsyncioTestCase):
     @classmethod
     def setUpClass(cls):
         cls.config_dir = get_config_dir()
-        cls.host = tcpip.LOCAL_HOST
+        cls.host = tcpip.LOCALHOST_IPV4
         cls.timeout_in_second = 0.05
 
         logging.basicConfig(
@@ -107,7 +107,7 @@ class TestController(unittest.IsolatedAsyncioTestCase):
         controller = Controller()
         await controller.close()
 
-        controller.start(tcpip.LOCAL_HOST, 0, 0)
+        controller.start(tcpip.LOCALHOST_IPV4, 0, 0)
         await controller.close()
 
     async def test_are_clients_connected(self):

--- a/tests/test_controller_cell.py
+++ b/tests/test_controller_cell.py
@@ -35,7 +35,7 @@ class TestControllerCell(unittest.IsolatedAsyncioTestCase):
     def setUpClass(cls):
 
         cls.log = logging.getLogger()
-        cls.host = tcpip.LOCAL_HOST
+        cls.host = tcpip.LOCALHOST_IPV4
 
         cls.config_dir = get_config_dir()
 

--- a/tests/test_controller_eui.py
+++ b/tests/test_controller_eui.py
@@ -58,7 +58,7 @@ class TestControllerEui(unittest.IsolatedAsyncioTestCase):
     @classmethod
     def setUpClass(cls):
         cls.config_dir = get_config_dir()
-        cls.host = tcpip.LOCAL_HOST
+        cls.host = tcpip.LOCALHOST_IPV4
         cls.timeout_in_second = 0.05
 
         logging.basicConfig(

--- a/tests/test_tcp_client.py
+++ b/tests/test_tcp_client.py
@@ -24,7 +24,6 @@ import asyncio
 import contextlib
 import json
 import logging
-import socket
 import unittest
 
 from lsst.ts import tcpip
@@ -40,7 +39,7 @@ class TestTcpClient(unittest.IsolatedAsyncioTestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.host = tcpip.LOCAL_HOST
+        cls.host = tcpip.LOCALHOST_IPV4
         cls.log = logging.getLogger()
         cls.times_previous_command = 3
 
@@ -53,7 +52,6 @@ class TestTcpClient(unittest.IsolatedAsyncioTestCase):
             port=0,
             name="test",
             log=self.log,
-            family=socket.AF_UNSPEC,
             connect_callback=None,
         )
         await server.start_task
@@ -104,7 +102,7 @@ class TestTcpClient(unittest.IsolatedAsyncioTestCase):
             await client.connect(timeout=3.0)
 
     async def test_close(self):
-        client = TcpClient(tcpip.LOCAL_HOST, 0)
+        client = TcpClient(tcpip.LOCALHOST_IPV4, 0)
         await client.close()
 
     async def test_is_connected(self):


### PR DESCRIPTION
* Adapt the **ts_tcpip** v1.0.0:

  * Use the **LOCALHOST_IPV4** instead of **LOCAL_HOST**.
  * Put the ``MockServer._connect_state_changed_callback_command()`` and ``MockServer._connect_state_changed_callback_telemetry()`` to be asynchronous.