### PR TITLE
Tickets/dm 38837

### DIFF
--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -8,6 +8,7 @@ v0.10.2
 * Add the ``Controller.set_control_parameters()`` to set the control parameters of closed-loop controller (CLC).
 * Do not check the communication power status (True/False) in ``Controller._callback_check_power_status()`` because sometimes, the cRIO simulator might put it on even though it should be off theoretically.
 * Allow to change the status of bit value of digital output.
+* Use the internal annotation instead of importing the **typing** module.
 
 v0.10.1
 -------

--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -2,6 +2,13 @@
 Version History
 ===============
 
+v0.10.2
+-------
+
+* Add the ``Controller.set_control_parameters()`` to set the control parameters of closed-loop controller (CLC).
+* Do not check the communication power status (True/False) in ``Controller._callback_check_power_status()`` because sometimes, the cRIO simulator might put it on even though it should be off theoretically.
+* Allow to change the status of bit value of digital output.
+
 v0.10.1
 -------
 

--- a/python/lsst/ts/m2com/controller.py
+++ b/python/lsst/ts/m2com/controller.py
@@ -601,7 +601,7 @@ class Controller:
         )
 
     def assert_controller_state(
-        self, command_name: str, allowed_curr_states: typing.List[salobj.State]
+        self, command_name: str, allowed_curr_states: list[salobj.State]
     ) -> None:
         """Assert the current controller's state is allowed to do the command
         or not.
@@ -831,7 +831,7 @@ class Controller:
         *args: typing.Any,
         time_wait_update: float = 0.5,
         timeout: float = 10.0,
-        **kwargs: typing.Dict[str, typing.Any],
+        **kwargs: dict[str, typing.Any],
     ) -> bool:
         """Check the expected value.
 

--- a/python/lsst/ts/m2com/controller.py
+++ b/python/lsst/ts/m2com/controller.py
@@ -39,7 +39,7 @@ from .enum import (
 )
 from .error_handler import ErrorHandler
 from .tcp_client import TcpClient
-from .utility import check_queue_size, get_config_dir
+from .utility import camel_case, check_queue_size, get_config_dir
 
 __all__ = ["Controller"]
 
@@ -90,6 +90,8 @@ class Controller:
         Closed loop control mode in the cell controller.
     ilc_modes : `numpy.ndarray [InnerLoopControlMode]`
         Modes of the inner-loop controller (ILC).
+    control_parameters : `dict`
+        Control parameters in the closed-loop controller (CLC).
     """
 
     def __init__(
@@ -134,6 +136,14 @@ class Controller:
         self.ilc_modes = np.array(
             [InnerLoopControlMode.Unknown] * NUM_INNER_LOOP_CONTROLLER
         )
+
+        self.control_parameters = {
+            "enable_lut_temperature": True,
+            "enable_lut_inclinometer": True,
+            "use_external_elevation_angle": False,
+            "enable_angle_comparison": False,
+            "max_angle_difference": 2.0,
+        }
 
         # Start the connection task or not
         self._start_connection = False
@@ -891,9 +901,10 @@ class Controller:
                 return True
 
         else:
-            if (self.power_system_status["communication_power_is_on"] == status) and (
-                self.power_system_status["communication_power_state"] == expected_state
-            ):
+            # cRIO simulator doesn't put the communication power to be off.
+            # Therefore, do not check
+            # 'self.power_system_status["communication_power_is_on"]' here.
+            if self.power_system_status["communication_power_state"] == expected_state:
                 return True
 
         return False
@@ -1230,3 +1241,15 @@ class Controller:
     async def load_configuration(self) -> None:
         """Load the configuration."""
         await self.write_command_to_server("loadConfiguration")
+
+    async def set_control_parameters(self) -> None:
+        """Set the control parameters of closed-loop controller (CLC)."""
+
+        message_details = dict()
+        for key, value in self.control_parameters.items():
+            message_details[camel_case(key)] = value
+
+        await self.write_command_to_server(
+            "setControlParameters",
+            message_details=message_details,
+        )

--- a/python/lsst/ts/m2com/controller_cell.py
+++ b/python/lsst/ts/m2com/controller_cell.py
@@ -213,7 +213,7 @@ class ControllerCell(Controller):
         self,
         process_event: typing.Callable | typing.Coroutine,
         *args: typing.Any,
-        **kwargs: typing.Dict[str, typing.Any],
+        **kwargs: dict[str, typing.Any],
     ) -> None:
         """Start the task of event loop.
 
@@ -236,7 +236,7 @@ class ControllerCell(Controller):
         self,
         process_event: typing.Callable | typing.Coroutine,
         *args: typing.Any,
-        **kwargs: typing.Dict[str, typing.Any],
+        **kwargs: dict[str, typing.Any],
     ) -> None:
         """Update and output event information from component.
 
@@ -286,7 +286,7 @@ class ControllerCell(Controller):
         process_telemetry: typing.Callable | typing.Coroutine,
         *args: typing.Any,
         period: float = 2.0,
-        **kwargs: typing.Dict[str, typing.Any],
+        **kwargs: dict[str, typing.Any],
     ) -> None:
         """Start the task of telemetry loop.
 
@@ -312,7 +312,7 @@ class ControllerCell(Controller):
         process_telemetry: typing.Callable | typing.Coroutine,
         *args: typing.Any,
         period: float = 2.0,
-        **kwargs: typing.Dict[str, typing.Any],
+        **kwargs: dict[str, typing.Any],
     ) -> None:
         """Update and output telemetry information from component.
 
@@ -403,7 +403,7 @@ class ControllerCell(Controller):
         process_lost_connection: typing.Callable | typing.Coroutine,
         *args: typing.Any,
         period: float = 1.0,
-        **kwargs: typing.Dict[str, typing.Any],
+        **kwargs: dict[str, typing.Any],
     ) -> None:
         """Start the task of connection monitor loop.
 
@@ -431,7 +431,7 @@ class ControllerCell(Controller):
         process_lost_connection: typing.Callable | typing.Coroutine,
         *args: typing.Any,
         period: float = 1.0,
-        **kwargs: typing.Dict[str, typing.Any],
+        **kwargs: dict[str, typing.Any],
     ) -> None:
         """Actively monitor the connection status from component. Disconnect
         the system if the connection is lost by itself.

--- a/python/lsst/ts/m2com/enum.py
+++ b/python/lsst/ts/m2com/enum.py
@@ -49,7 +49,7 @@ class BitEnum(Enum):
 
     @staticmethod
     def _generate_next_value_(
-        name: str, start: int, count: int, last_values: typing.List[typing.Any]
+        name: str, start: int, count: int, last_values: list[typing.Any]
     ) -> int:
         """Override parent method to generate power of 2 sequence of numbers,
         starting from 1 (e.g. 1, 2, 4, 8, ...)."""

--- a/python/lsst/ts/m2com/enum.py
+++ b/python/lsst/ts/m2com/enum.py
@@ -32,6 +32,7 @@ __all__ = [
     "PowerType",
     "PowerSystemState",
     "DigitalOutput",
+    "DigitalOutputStatus",
     "DigitalInput",
     "LimitSwitchType",
     "ClosedLoopControlMode",
@@ -136,6 +137,15 @@ class DigitalOutput(BitEnum):
     SpareOutput_5 = auto()
     SpareOutput_6 = auto()
     SpareOutput_7 = auto()
+
+
+class DigitalOutputStatus(IntEnum):
+    """Digital output status to switch the individual bit value of
+    digital output."""
+
+    BinaryLowLevel = 1
+    BinaryHighLevel = auto()
+    ToggleBit = auto()
 
 
 class DigitalInput(BitEnum):

--- a/python/lsst/ts/m2com/mock/mock_command.py
+++ b/python/lsst/ts/m2com/mock/mock_command.py
@@ -20,7 +20,6 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import asyncio
-import typing
 
 from lsst.ts import salobj
 from lsst.ts.idl.enums import MTM2
@@ -67,7 +66,7 @@ class MockCommand:
 
     async def enable(
         self, message: dict, model: MockModel, message_event: MockMessageEvent
-    ) -> typing.Tuple[MockModel, CommandStatus]:
+    ) -> tuple[MockModel, CommandStatus]:
         """Enable the system.
 
         Parameters
@@ -201,7 +200,7 @@ class MockCommand:
 
     async def disable(
         self, message: dict, model: MockModel, message_event: MockMessageEvent
-    ) -> typing.Tuple[MockModel, CommandStatus]:
+    ) -> tuple[MockModel, CommandStatus]:
         """Disable the system.
 
         Parameters
@@ -240,7 +239,7 @@ class MockCommand:
 
     async def standby(
         self, message: dict, model: MockModel, message_event: MockMessageEvent
-    ) -> typing.Tuple[MockModel, CommandStatus]:
+    ) -> tuple[MockModel, CommandStatus]:
         """Standby the system.
 
         Parameters
@@ -273,7 +272,7 @@ class MockCommand:
 
     async def start(
         self, message: dict, model: MockModel, message_event: MockMessageEvent
-    ) -> typing.Tuple[MockModel, CommandStatus]:
+    ) -> tuple[MockModel, CommandStatus]:
         """Start the system.
 
         Parameters
@@ -305,7 +304,7 @@ class MockCommand:
 
     async def enter_control(
         self, message: dict, model: MockModel, message_event: MockMessageEvent
-    ) -> typing.Tuple[MockModel, CommandStatus]:
+    ) -> tuple[MockModel, CommandStatus]:
         """Enter the control.
 
         This is only supported for the commandable SAL component (CSC). In the
@@ -341,7 +340,7 @@ class MockCommand:
 
     async def exit_control(
         self, message: dict, model: MockModel, message_event: MockMessageEvent
-    ) -> typing.Tuple[MockModel, CommandStatus]:
+    ) -> tuple[MockModel, CommandStatus]:
         """Exit the control.
 
         This is only supported for the commandable SAL component (CSC). In the
@@ -391,7 +390,7 @@ class MockCommand:
 
     async def apply_forces(
         self, message: dict, model: MockModel, message_event: MockMessageEvent
-    ) -> typing.Tuple[MockModel, CommandStatus]:
+    ) -> tuple[MockModel, CommandStatus]:
         """Apply the forces in addtional to the LUT force.
 
         LUT: look-up table.
@@ -425,7 +424,7 @@ class MockCommand:
 
     async def position_mirror(
         self, message: dict, model: MockModel, message_event: MockMessageEvent
-    ) -> typing.Tuple[MockModel, CommandStatus]:
+    ) -> tuple[MockModel, CommandStatus]:
         """Position the mirror.
 
         Parameters
@@ -474,7 +473,7 @@ class MockCommand:
 
     async def reset_force_offsets(
         self, message: dict, model: MockModel, message_event: MockMessageEvent
-    ) -> typing.Tuple[MockModel, CommandStatus]:
+    ) -> tuple[MockModel, CommandStatus]:
         """Reset the actuator force offsets (not LUT force).
 
         LUT: look-up table.
@@ -503,7 +502,7 @@ class MockCommand:
 
     async def clear_errors(
         self, message: dict, model: MockModel, message_event: MockMessageEvent
-    ) -> typing.Tuple[MockModel, CommandStatus]:
+    ) -> tuple[MockModel, CommandStatus]:
         """Clear the system errors.
 
         Parameters
@@ -537,7 +536,7 @@ class MockCommand:
 
     async def switch_force_balance_system(
         self, message: dict, model: MockModel, message_event: MockMessageEvent
-    ) -> typing.Tuple[MockModel, CommandStatus]:
+    ) -> tuple[MockModel, CommandStatus]:
         """Switch the force balance system.
 
         Parameters
@@ -584,7 +583,7 @@ class MockCommand:
 
     async def select_inclination_source(
         self, message: dict, model: MockModel, message_event: MockMessageEvent
-    ) -> typing.Tuple[MockModel, CommandStatus]:
+    ) -> tuple[MockModel, CommandStatus]:
         """Select the source of inclination.
 
         Notes
@@ -621,7 +620,7 @@ class MockCommand:
 
     async def set_temperature_offset(
         self, message: dict, model: MockModel, message_event: MockMessageEvent
-    ) -> typing.Tuple[MockModel, CommandStatus]:
+    ) -> tuple[MockModel, CommandStatus]:
         """Set the temperature offset used in the calculation of LUT force.
 
         LUT: look-up table.
@@ -655,7 +654,7 @@ class MockCommand:
 
     async def switch_command_source(
         self, message: dict, model: MockModel, message_event: MockMessageEvent
-    ) -> typing.Tuple[MockModel, CommandStatus]:
+    ) -> tuple[MockModel, CommandStatus]:
         """Switch the command source to be the commandable SAL component (CSC)
         or engineering user interface (EUI).
 
@@ -683,7 +682,7 @@ class MockCommand:
 
     async def run_script(
         self, message: dict, model: MockModel, message_event: MockMessageEvent
-    ) -> typing.Tuple[MockModel, CommandStatus]:
+    ) -> tuple[MockModel, CommandStatus]:
         """Run the binary script used in the engineering user interface (EUI).
 
         Parameters
@@ -728,7 +727,7 @@ class MockCommand:
 
     async def move_actuators(
         self, message: dict, model: MockModel, message_event: MockMessageEvent
-    ) -> typing.Tuple[MockModel, CommandStatus]:
+    ) -> tuple[MockModel, CommandStatus]:
         """Move the actuators.
 
         Parameters
@@ -773,7 +772,7 @@ class MockCommand:
 
     async def reset_breakers(
         self, message: dict, model: MockModel, message_event: MockMessageEvent
-    ) -> typing.Tuple[MockModel, CommandStatus]:
+    ) -> tuple[MockModel, CommandStatus]:
         """Reset the breakers.
 
         Parameters
@@ -853,7 +852,7 @@ class MockCommand:
 
     async def reboot_controller(
         self, message: dict, model: MockModel, message_event: MockMessageEvent
-    ) -> typing.Tuple[MockModel, CommandStatus]:
+    ) -> tuple[MockModel, CommandStatus]:
         """Reboot the cell controller.
 
         Parameters
@@ -877,7 +876,7 @@ class MockCommand:
 
     async def enable_open_loop_max_limit(
         self, message: dict, model: MockModel, message_event: MockMessageEvent
-    ) -> typing.Tuple[MockModel, CommandStatus]:
+    ) -> tuple[MockModel, CommandStatus]:
         """Enable the maximum limit in open-loop control.
 
         Parameters
@@ -910,7 +909,7 @@ class MockCommand:
 
     async def save_mirror_position(
         self, message: dict, model: MockModel, message_event: MockMessageEvent
-    ) -> typing.Tuple[MockModel, CommandStatus]:
+    ) -> tuple[MockModel, CommandStatus]:
         """Save the position of mirror.
 
         Parameters
@@ -934,7 +933,7 @@ class MockCommand:
 
     async def set_mirror_home(
         self, message: dict, model: MockModel, message_event: MockMessageEvent
-    ) -> typing.Tuple[MockModel, CommandStatus]:
+    ) -> tuple[MockModel, CommandStatus]:
         """Set the home of mirror.
 
         Parameters
@@ -965,7 +964,7 @@ class MockCommand:
 
     async def switch_digital_output(
         self, message: dict, model: MockModel, message_event: MockMessageEvent
-    ) -> typing.Tuple[MockModel, CommandStatus]:
+    ) -> tuple[MockModel, CommandStatus]:
         """Switch the digital output.
 
         Parameters
@@ -1020,7 +1019,7 @@ class MockCommand:
 
     async def power(
         self, message: dict, model: MockModel, message_event: MockMessageEvent
-    ) -> typing.Tuple[MockModel, CommandStatus]:
+    ) -> tuple[MockModel, CommandStatus]:
         """Power on/off the motor/communication system.
 
         Parameters
@@ -1083,7 +1082,7 @@ class MockCommand:
 
     async def reset_actuator_steps(
         self, message: dict, model: MockModel, message_event: MockMessageEvent
-    ) -> typing.Tuple[MockModel, CommandStatus]:
+    ) -> tuple[MockModel, CommandStatus]:
         """Reset the actuator steps.
 
         Notes
@@ -1112,7 +1111,7 @@ class MockCommand:
 
     async def set_closed_loop_control_mode(
         self, message: dict, model: MockModel, message_event: MockMessageEvent
-    ) -> typing.Tuple[MockModel, CommandStatus]:
+    ) -> tuple[MockModel, CommandStatus]:
         """Set the closed-loop control mode.
 
         Parameters
@@ -1144,7 +1143,7 @@ class MockCommand:
 
     async def set_inner_loop_control_mode(
         self, message: dict, model: MockModel, message_event: MockMessageEvent
-    ) -> typing.Tuple[MockModel, CommandStatus]:
+    ) -> tuple[MockModel, CommandStatus]:
         """Set the inner-loop control mode.
 
         Parameters
@@ -1186,7 +1185,7 @@ class MockCommand:
 
     async def get_inner_loop_control_mode(
         self, message: dict, model: MockModel, message_event: MockMessageEvent
-    ) -> typing.Tuple[MockModel, CommandStatus]:
+    ) -> tuple[MockModel, CommandStatus]:
         """get the inner-loop control mode.
 
         Parameters
@@ -1224,7 +1223,7 @@ class MockCommand:
 
     async def load_configuration(
         self, message: dict, model: MockModel, message_event: MockMessageEvent
-    ) -> typing.Tuple[MockModel, CommandStatus]:
+    ) -> tuple[MockModel, CommandStatus]:
         """Load the configuration.
 
         Parameters
@@ -1250,7 +1249,7 @@ class MockCommand:
 
     async def set_control_parameters(
         self, message: dict, model: MockModel, message_event: MockMessageEvent
-    ) -> typing.Tuple[MockModel, CommandStatus]:
+    ) -> tuple[MockModel, CommandStatus]:
         """Set the closed-loop controller (CLC) control parameters.
 
         Parameters

--- a/python/lsst/ts/m2com/mock/mock_control_closed_loop.py
+++ b/python/lsst/ts/m2com/mock/mock_control_closed_loop.py
@@ -21,7 +21,6 @@
 
 __all__ = ["MockControlClosedLoop"]
 
-import typing
 from pathlib import Path
 
 import numpy as np
@@ -111,10 +110,10 @@ class MockControlClosedLoop:
         self.in_position_hardpoints = False
 
         # Look-up tables (LUTs)
-        self._lut: typing.Dict = dict()
+        self._lut: dict = dict()
 
         # Cell geometry used in the calculation of net total forces and moments
-        self._cell_geom: typing.Dict = dict()
+        self._cell_geom: dict = dict()
 
         # Hardpoint compensation matrix
         self._hd_comp = np.array([])
@@ -381,12 +380,10 @@ class MockControlClosedLoop:
 
     @staticmethod
     def calc_hp_comp_matrix(
-        location_axial_actuator: typing.List[list],
-        hardpoints_axial: typing.List[int],
-        hardpoints_tangent: typing.List[int],
-    ) -> typing.Tuple[
-        numpy.typing.NDArray[np.float64], numpy.typing.NDArray[np.float64]
-    ]:
+        location_axial_actuator: list[list],
+        hardpoints_axial: list[int],
+        hardpoints_tangent: list[int],
+    ) -> tuple[numpy.typing.NDArray[np.float64], numpy.typing.NDArray[np.float64]]:
         """Calculate the hardpoint compensation matrix.
 
         Notes
@@ -484,7 +481,7 @@ class MockControlClosedLoop:
 
     @staticmethod
     def select_axial_hardpoints(
-        location_axial_actuator: typing.List[list], specific_axial_hardpoint: int
+        location_axial_actuator: list[list], specific_axial_hardpoint: int
     ) -> list:
         """Select the axial hardpoints based on the specific axial hardpoint.
 
@@ -538,8 +535,8 @@ class MockControlClosedLoop:
 
     @staticmethod
     def rigid_body_to_actuator_displacement(
-        location_axial_actuator: typing.List[list],
-        location_tangent_link: typing.List[float],
+        location_axial_actuator: list[list],
+        location_tangent_link: list[float],
         radius: float,
         dx: float,
         dy: float,
@@ -641,13 +638,13 @@ class MockControlClosedLoop:
 
     @staticmethod
     def hardpoint_to_rigid_body(
-        location_axial_actuator: typing.List[list],
-        location_tangent_link: typing.List[float],
+        location_axial_actuator: list[list],
+        location_tangent_link: list[float],
         radius: float,
-        hardpoints: typing.List[int],
-        disp_hardpoint_current: typing.List[float],
-        disp_hardpoint_home: typing.List[float],
-    ) -> typing.Tuple[float, float, float, float, float, float]:
+        hardpoints: list[int],
+        disp_hardpoint_current: list[float],
+        disp_hardpoint_home: list[float],
+    ) -> tuple[float, float, float, float, float, float]:
         """Calculate the rigid body position based on the hardpoint
         displacements.
 
@@ -777,9 +774,9 @@ class MockControlClosedLoop:
     @staticmethod
     def calculate_rigid_body_xy(
         radius: float,
-        tangent_hardpoint_displacement: typing.List[float],
-        tangent_hardpoint_location: typing.List[float],
-    ) -> typing.Tuple[float, float, numpy.typing.NDArray[np.float64]]:
+        tangent_hardpoint_displacement: list[float],
+        tangent_hardpoint_location: list[float],
+    ) -> tuple[float, float, numpy.typing.NDArray[np.float64]]:
         """Calculate the rigid body (x, y) position.
 
         Notes
@@ -842,8 +839,8 @@ class MockControlClosedLoop:
 
     def apply_forces(
         self,
-        force_axial: typing.List[float] | numpy.typing.NDArray[np.float64],
-        force_tangent: typing.List[float] | numpy.typing.NDArray[np.float64],
+        force_axial: list[float] | numpy.typing.NDArray[np.float64],
+        force_tangent: list[float] | numpy.typing.NDArray[np.float64],
     ) -> None:
         """Apply the actuator forces.
 
@@ -876,7 +873,7 @@ class MockControlClosedLoop:
         applied_force_axial: numpy.typing.NDArray[np.float64] | None = None,
         applied_force_tangent: numpy.typing.NDArray[np.float64] | None = None,
         use_measured_force: bool = False,
-    ) -> typing.Tuple[bool, list, list]:
+    ) -> tuple[bool, list, list]:
         """The actuator force is out of limit or not.
 
         Notes
@@ -1142,7 +1139,7 @@ class MockControlClosedLoop:
         self,
         lut_temperature: numpy.typing.NDArray[np.float64],
         ref_temperature: numpy.typing.NDArray[np.float64],
-    ) -> typing.Tuple[
+    ) -> tuple[
         numpy.typing.NDArray[np.float64],
         numpy.typing.NDArray[np.float64],
         numpy.typing.NDArray[np.float64],
@@ -1189,7 +1186,7 @@ class MockControlClosedLoop:
 
     def _calc_look_up_forces_gravity(
         self, lut_angle: float
-    ) -> typing.Tuple[
+    ) -> tuple[
         numpy.typing.NDArray[np.float64],
         numpy.typing.NDArray[np.float64],
         numpy.typing.NDArray[np.float64],
@@ -1329,7 +1326,7 @@ class MockControlClosedLoop:
 
     def _force_dynamics(
         self, force_rms: float, force_per_cycle: float
-    ) -> typing.Tuple[bool, numpy.typing.NDArray[np.float64]]:
+    ) -> tuple[bool, numpy.typing.NDArray[np.float64]]:
         """Handle the force dynamics.
 
         The method works by comparing the demanded forces with the current
@@ -1413,7 +1410,7 @@ class MockControlClosedLoop:
 
     def _get_force_error(
         self,
-    ) -> typing.Tuple[
+    ) -> tuple[
         numpy.typing.NDArray[np.float64],
         numpy.typing.NDArray[np.float64],
         numpy.typing.NDArray[np.float64],

--- a/python/lsst/ts/m2com/mock/mock_control_open_loop.py
+++ b/python/lsst/ts/m2com/mock/mock_control_open_loop.py
@@ -21,7 +21,6 @@
 
 __all__ = ["MockControlOpenLoop"]
 
-import typing
 from pathlib import Path
 
 import numpy as np
@@ -74,7 +73,7 @@ class MockControlOpenLoop:
         self.actuator_steps = np.zeros(NUM_ACTUATOR, dtype=int)
 
         # Selected actuator IDs to do the movement
-        self._selected_actuators: typing.List[int] = list()
+        self._selected_actuators: list[int] = list()
 
         # Displacement of steps to do the movement
         self._displacement_steps = 0
@@ -208,7 +207,7 @@ class MockControlOpenLoop:
 
         return forces
 
-    def is_actuator_force_out_limit(self) -> typing.Tuple[bool, list, list]:
+    def is_actuator_force_out_limit(self) -> tuple[bool, list, list]:
         """The actuator force is out of limit or not. The result will depend
         on self.open_loop_max_limit_is_enabled.
 
@@ -320,7 +319,7 @@ class MockControlOpenLoop:
 
     def start(
         self,
-        actuators: typing.List[int],
+        actuators: list[int],
         displacement: int | float,
         unit: ActuatorDisplacementUnit,
     ) -> None:
@@ -446,8 +445,8 @@ class MockControlOpenLoop:
 
     def move_actuator_steps(
         self,
-        actuators: typing.List[int] | numpy.typing.NDArray[np.int64],
-        steps: int | typing.List[int] | numpy.typing.NDArray[np.int64],
+        actuators: list[int] | numpy.typing.NDArray[np.int64],
+        steps: int | list[int] | numpy.typing.NDArray[np.int64],
     ) -> None:
         """Move the actuator steps.
 

--- a/python/lsst/ts/m2com/mock/mock_message_event.py
+++ b/python/lsst/ts/m2com/mock/mock_message_event.py
@@ -20,7 +20,6 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import asyncio
-import typing
 
 from lsst.ts import salobj
 from lsst.ts.idl.enums import MTM2
@@ -165,7 +164,7 @@ class MockMessageEvent:
                 self.writer, {"id": "tcpIpConnected", "isConnected": is_connected}
             )
 
-    async def write_hardpoint_list(self, actuators: typing.List[int]) -> None:
+    async def write_hardpoint_list(self, actuators: list[int]) -> None:
         """Write the message: hardpoint list.
 
         Parameters
@@ -209,7 +208,7 @@ class MockMessageEvent:
                 self.writer, {"id": "inclinationTelemetrySource", "source": int(source)}
             )
 
-    async def write_temperature_offset(self, ring: typing.List[int | float]) -> None:
+    async def write_temperature_offset(self, ring: list[int | float]) -> None:
         """Write the message: temperature offset in degree C.
 
         Parameters
@@ -320,8 +319,8 @@ class MockMessageEvent:
 
     async def write_limit_switch_status(
         self,
-        limit_switch_retract: typing.List[int],
-        limit_switch_extend: typing.List[int],
+        limit_switch_retract: list[int],
+        limit_switch_extend: list[int],
     ) -> None:
         """Write the message: limit switch status.
 

--- a/python/lsst/ts/m2com/mock/mock_model.py
+++ b/python/lsst/ts/m2com/mock/mock_model.py
@@ -159,7 +159,7 @@ class MockModel:
             self.list_ilc.append(MockInnerLoopController())
 
         # Parameters of independent displacement sensors (IMS)
-        self._disp_ims: typing.Dict = dict()
+        self._disp_ims: dict = dict()
 
         self.mtmount_in_position: bool = False
 
@@ -340,7 +340,7 @@ class MockModel:
 
     def is_actuator_force_out_limit(
         self,
-    ) -> typing.Tuple[bool, MockErrorCode, list, list]:
+    ) -> tuple[bool, MockErrorCode, list, list]:
         """The actuator force is out of limit or not.
 
         By default, return the judgement based on the open-loop control. If
@@ -1073,9 +1073,7 @@ class MockModel:
         else:
             raise RuntimeError(f"Not supported status: {status!r}.")
 
-    def set_mode_ilc(
-        self, addresses: typing.List[int], mode: InnerLoopControlMode
-    ) -> None:
+    def set_mode_ilc(self, addresses: list[int], mode: InnerLoopControlMode) -> None:
         """Set the mode of inner-loop controller (ILC).
 
         Parameters
@@ -1089,9 +1087,7 @@ class MockModel:
         for address in addresses:
             self.list_ilc[address].set_mode(mode)
 
-    def get_mode_ilc(
-        self, addresses: typing.List[int]
-    ) -> typing.List[InnerLoopControlMode]:
+    def get_mode_ilc(self, addresses: list[int]) -> list[InnerLoopControlMode]:
         """Get the mode of inner-loop controller (ILC).
 
         Parameters

--- a/python/lsst/ts/m2com/mock/mock_model.py
+++ b/python/lsst/ts/m2com/mock/mock_model.py
@@ -36,6 +36,7 @@ from ..constant import (
 from ..enum import (
     DigitalInput,
     DigitalOutput,
+    DigitalOutputStatus,
     InnerLoopControlMode,
     MockErrorCode,
     PowerType,
@@ -1031,7 +1032,9 @@ class MockModel:
 
         return digital_input
 
-    def switch_digital_output(self, digital_output: int, bit: DigitalOutput) -> int:
+    def switch_digital_output(
+        self, digital_output: int, bit: DigitalOutput, status: DigitalOutputStatus
+    ) -> int:
         """Switch the digital output with the specific bit.
 
         Parameters
@@ -1040,17 +1043,35 @@ class MockModel:
             Digital output.
         bit : enum `DigitalOutput`
             Bit to switch.
+        status : enum `DigitalOutputStatus`
+            Digital output status.
 
         Returns
         -------
         `int`
             Updated value of the digital output.
+
+        Raises
+        ------
+        `RuntimeError`
+            If the status is not supported.
         """
-        return (
-            (digital_output - bit.value)
-            if (digital_output & bit.value)
-            else (digital_output + bit.value)
-        )
+
+        if status == DigitalOutputStatus.BinaryLowLevel:
+            return (digital_output | bit.value) - bit.value
+
+        elif status == DigitalOutputStatus.BinaryHighLevel:
+            return digital_output | bit.value
+
+        elif status == DigitalOutputStatus.ToggleBit:
+            return (
+                (digital_output - bit.value)
+                if (digital_output & bit.value)
+                else (digital_output + bit.value)
+            )
+
+        else:
+            raise RuntimeError(f"Not supported status: {status!r}.")
 
     def set_mode_ilc(
         self, addresses: typing.List[int], mode: InnerLoopControlMode

--- a/python/lsst/ts/m2com/mock/mock_power_system.py
+++ b/python/lsst/ts/m2com/mock/mock_power_system.py
@@ -20,7 +20,6 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import asyncio
-import typing
 
 import numpy as np
 
@@ -103,7 +102,7 @@ class MockPowerSystem:
             PowerSystemState.PoweredOn,
         )
 
-    def get_power(self, rms: float = 0.05) -> typing.Tuple[float, float]:
+    def get_power(self, rms: float = 0.05) -> tuple[float, float]:
         """Get the power.
 
         Parameters

--- a/python/lsst/ts/m2com/mock/mock_server.py
+++ b/python/lsst/ts/m2com/mock/mock_server.py
@@ -156,6 +156,7 @@ class MockServer:
             "cmd_setInnerLoopControlMode": self._command.set_inner_loop_control_mode,
             "cmd_getInnerLoopControlMode": self._command.get_inner_loop_control_mode,
             "cmd_loadConfiguration": self._command.load_configuration,
+            "cmd_setControlParameters": self._command.set_control_parameters,
         }
 
     async def _connect_state_changed_callback_command(

--- a/python/lsst/ts/m2com/utility.py
+++ b/python/lsst/ts/m2com/utility.py
@@ -254,7 +254,7 @@ def check_limit_switches(
     actuator_forces: numpy.typing.NDArray[np.float64],
     limit_force_axial: float,
     limit_force_tangent: float,
-) -> typing.Tuple[bool, list, list]:
+) -> tuple[bool, list, list]:
     """Check the limit switches are triggered or not.
 
     Parameters

--- a/python/lsst/ts/m2com/utility.py
+++ b/python/lsst/ts/m2com/utility.py
@@ -27,6 +27,7 @@ import typing
 from copy import deepcopy
 from os import getenv
 from pathlib import Path
+from re import sub
 
 import numpy as np
 import numpy.typing
@@ -45,6 +46,7 @@ __all__ = [
     "get_config_dir",
     "is_coroutine",
     "check_limit_switches",
+    "camel_case",
 ]
 
 
@@ -317,3 +319,26 @@ def check_limit_switches(
     is_triggered = (len(limit_switch_retract) != 0) or (len(limit_switch_extend) != 0)
 
     return is_triggered, limit_switch_retract.tolist(), limit_switch_extend.tolist()
+
+
+def camel_case(string_python: str) -> str:
+    """Formate the string of Python style to camel case. For example, 'ab_cd'
+    will be reformated to 'abCd'.
+
+    Copy from:
+    https://www.w3resource.com/python-exercises/string/
+    python-data-type-string-exercise-96.php
+
+    Parameters
+    ----------
+    string_python : `str`
+        Python-style string.
+
+    Returns
+    -------
+    `str`
+        String of camel case.
+    """
+
+    string_reformat = sub(r"(_|-)+", " ", string_python).title().replace(" ", "")
+    return "".join([string_reformat[0].lower(), string_reformat[1:]])

--- a/tests/mock/test_mock_control_closed_loop.py
+++ b/tests/mock/test_mock_control_closed_loop.py
@@ -19,7 +19,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import typing
 import unittest
 
 import numpy as np
@@ -313,7 +312,7 @@ class TestMockControlClosedLoop(unittest.TestCase):
             self.control_closed_loop.tangent_forces["applied"], force_tangent
         )
 
-    def _apply_forces(self) -> typing.Tuple[list, list]:
+    def _apply_forces(self) -> tuple[list, list]:
         force_axial = [1] * (NUM_ACTUATOR - NUM_TANGENT_LINK)
         force_tangent = [2] * NUM_TANGENT_LINK
         self.control_closed_loop.apply_forces(force_axial, force_tangent)
@@ -586,7 +585,7 @@ class TestMockControlClosedLoop(unittest.TestCase):
 
     def _get_force_measured_and_lut_angle(
         self, angle: float
-    ) -> typing.Tuple[numpy.typing.NDArray[np.float64], float]:
+    ) -> tuple[numpy.typing.NDArray[np.float64], float]:
         control_open_loop = MockControlOpenLoop()
         return control_open_loop.get_forces_mirror_weight(
             angle

--- a/tests/mock/test_mock_model.py
+++ b/tests/mock/test_mock_model.py
@@ -19,7 +19,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import typing
 import unittest
 
 import numpy as np
@@ -219,7 +218,7 @@ class TestMockModel(unittest.IsolatedAsyncioTestCase):
         tangent_actuator_positions = telemetry_data["tangentEncoderPositions"]
         self.assertEqual(len(tangent_actuator_positions["position"]), NUM_TANGENT_LINK)
 
-    def _apply_forces(self) -> typing.Tuple[list, list]:
+    def _apply_forces(self) -> tuple[list, list]:
         force_axial = [1] * (NUM_ACTUATOR - NUM_TANGENT_LINK)
         force_tangent = [2] * NUM_TANGENT_LINK
         self.model.control_closed_loop.apply_forces(force_axial, force_tangent)
@@ -283,7 +282,7 @@ class TestMockModel(unittest.IsolatedAsyncioTestCase):
 
     def _get_force_error_tangent_expected(
         self,
-    ) -> typing.Tuple[float, numpy.typing.NDArray[np.float64], dict]:
+    ) -> tuple[float, numpy.typing.NDArray[np.float64], dict]:
         return (
             89.853,
             np.array([-325.307, -447.377, 1128.37, -1249.98, 458.63, 267.627]),

--- a/tests/mock/test_mock_model.py
+++ b/tests/mock/test_mock_model.py
@@ -35,6 +35,7 @@ from lsst.ts.m2com import (
     TEST_DIGITAL_OUTPUT_POWER_COMM,
     TEST_DIGITAL_OUTPUT_POWER_COMM_MOTOR,
     DigitalOutput,
+    DigitalOutputStatus,
     InnerLoopControlMode,
     MockErrorCode,
     MockModel,
@@ -490,15 +491,49 @@ class TestMockModel(unittest.IsolatedAsyncioTestCase):
     def test_switch_digital_output(self) -> None:
         digital_output = self.model.get_digital_output()
 
+        # Binary low
+        digital_output_low_none = self.model.switch_digital_output(
+            digital_output, DigitalOutput.MotorPower, DigitalOutputStatus.BinaryLowLevel
+        )
+        self.assertEqual(digital_output_low_none, digital_output)
+
+        digital_output_low_exist = self.model.switch_digital_output(
+            digital_output,
+            DigitalOutput.ResetMotorBreakers,
+            DigitalOutputStatus.BinaryLowLevel,
+        )
+        self.assertEqual(
+            digital_output_low_exist,
+            digital_output - DigitalOutput.ResetMotorBreakers.value,
+        )
+
+        # Binary high
+        digital_output_high_none = self.model.switch_digital_output(
+            digital_output,
+            DigitalOutput.MotorPower,
+            DigitalOutputStatus.BinaryHighLevel,
+        )
+        self.assertEqual(
+            digital_output_high_none, digital_output + DigitalOutput.MotorPower.value
+        )
+
+        digital_output_high_exist = self.model.switch_digital_output(
+            digital_output,
+            DigitalOutput.ResetMotorBreakers,
+            DigitalOutputStatus.BinaryHighLevel,
+        )
+        self.assertEqual(digital_output_high_exist, digital_output)
+
+        # Toggle bit
         digital_output_with_motor_power = self.model.switch_digital_output(
-            digital_output, DigitalOutput.MotorPower
+            digital_output, DigitalOutput.MotorPower, DigitalOutputStatus.ToggleBit
         )
         self.assertTrue(
             digital_output_with_motor_power & DigitalOutput.MotorPower.value
         )
 
         digital_output_interlock_disabled = self.model.switch_digital_output(
-            digital_output, DigitalOutput.InterlockEnable
+            digital_output, DigitalOutput.InterlockEnable, DigitalOutputStatus.ToggleBit
         )
         self.assertFalse(
             digital_output_interlock_disabled & DigitalOutput.InterlockEnable.value

--- a/tests/mock/test_mock_server.py
+++ b/tests/mock/test_mock_server.py
@@ -852,6 +852,33 @@ class TestMockServer(unittest.IsolatedAsyncioTestCase):
             # command
             self.assertEqual(len(msg_config), 2)
 
+    async def test_cmd_set_control_parameters(self) -> None:
+        async with self.make_server() as server, self.make_clients(server) as (
+            client_cmd,
+            client_tel,
+        ):
+            await client_cmd.write(
+                MsgType.Command,
+                "setControlParameters",
+                msg_details={
+                    "enableLutTemperature": True,
+                    "enableLutInclinometer": True,
+                    "useExternalElevationAngle": True,
+                    "enableAngleComparison": True,
+                    "maxAngleDifference": 2.0,
+                },
+            )
+
+            await asyncio.sleep(0.5)
+
+            source = MTM2.InclinationTelemetrySource.MTMOUNT
+            self.assertEqual(server.model.inclination_source, source)
+
+            msg_source = get_queue_message_latest(
+                client_cmd.queue, "inclinationTelemetrySource"
+            )
+            self.assertEqual(msg_source["source"], int(source))
+
 
 if __name__ == "__main__":
     # Do the unit test

--- a/tests/test_controller_eui.py
+++ b/tests/test_controller_eui.py
@@ -38,6 +38,7 @@ from lsst.ts.m2com import (
     CommandStatus,
     Controller,
     DigitalOutput,
+    DigitalOutputStatus,
     MockErrorCode,
     MockServer,
     PowerType,
@@ -582,7 +583,7 @@ class TestControllerEui(unittest.IsolatedAsyncioTestCase):
             # No this bit value
             with self.assertRaises(RuntimeError):
                 await controller.write_command_to_server(
-                    "switchDigitalOutput", message_details={"bit": 0}
+                    "switchDigitalOutput", message_details={"bit": 0, "status": 3}
                 )
 
     async def test_switch_digital_output_success(self) -> None:
@@ -592,7 +593,10 @@ class TestControllerEui(unittest.IsolatedAsyncioTestCase):
             # Switch the communication power
             await controller.write_command_to_server(
                 "switchDigitalOutput",
-                message_details={"bit": DigitalOutput.CommunicationPower.value},
+                message_details={
+                    "bit": DigitalOutput.CommunicationPower.value,
+                    "status": DigitalOutputStatus.ToggleBit.value,
+                },
             )
 
             await asyncio.sleep(SLEEP_TIME_SHORT)
@@ -608,7 +612,10 @@ class TestControllerEui(unittest.IsolatedAsyncioTestCase):
             # Switch the motor power
             await controller.write_command_to_server(
                 "switchDigitalOutput",
-                message_details={"bit": DigitalOutput.MotorPower.value},
+                message_details={
+                    "bit": DigitalOutput.MotorPower.value,
+                    "status": DigitalOutputStatus.ToggleBit.value,
+                },
             )
 
             await asyncio.sleep(SLEEP_TIME_SHORT)

--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -26,6 +26,7 @@ import unittest
 import numpy as np
 from lsst.ts.m2com import (
     NUM_ACTUATOR,
+    camel_case,
     check_limit_switches,
     check_queue_size,
     get_config_dir,
@@ -114,6 +115,10 @@ class TestUtility(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(is_triggered)
         self.assertEqual(limit_switch_retract, [0, 71, 72, 77])
         self.assertEqual(limit_switch_extend, [1, 5, 73, 74])
+
+    def test_camel_case(self) -> None:
+        self.assertEqual(camel_case("ab"), "ab")
+        self.assertEqual(camel_case("ab_cd"), "abCd")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
* Add the ``Controller.set_control_parameters()`` to set the control parameters of closed-loop controller (CLC).
* Do not check the communication power status (True/False) in ``Controller._callback_check_power_status()`` because sometimes, the cRIO simulator might put it on even though it should be off theoretically.
* Allow to change the status of bit value of digital output.
* Use the internal annotation instead of importing the **typing** module.