### PR TITLE
Tickets/dm 38791

### DIFF
--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -2,6 +2,12 @@
 Version History
 ===============
 
+v0.10.3
+-------
+
+* Add the ``MockCommand.report_interlock()`` to report the interlock event.
+* Update the ``MockServer._send_welcome_message()`` to send the lost connection error at welcome message.
+
 v0.10.2
 -------
 

--- a/python/lsst/ts/m2com/enum.py
+++ b/python/lsst/ts/m2com/enum.py
@@ -222,5 +222,6 @@ class MockErrorCode(IntEnum):
 
     NoError = 1
     MonitoringIlcReadError = 6052
+    LostConnection = 6053
     LimitSwitchTriggeredClosedloop = 6056
     LimitSwitchTriggeredOpenloop = 6057

--- a/python/lsst/ts/m2com/mock/mock_command.py
+++ b/python/lsst/ts/m2com/mock/mock_command.py
@@ -197,6 +197,19 @@ class MockCommand:
 
         self._digital_output = model.get_digital_output()
         await message_event.write_digital_output(self._digital_output)
+        await self.report_interlock(message_event)
+
+    async def report_interlock(self, message_event: MockMessageEvent) -> None:
+        """Report the interlock status.
+
+        Parameters
+        ----------
+        message_event : MockMessageEvent
+            Instance of MockMessageEvent to write the event.
+        """
+        await message_event.write_interlock(
+            bool(self._digital_output & DigitalOutput.InterlockEnable.value)
+        )
 
     async def disable(
         self, message: dict, model: MockModel, message_event: MockMessageEvent
@@ -827,6 +840,8 @@ class MockCommand:
                 )
 
             await message_event.write_digital_output(digital_output_reset)
+            await self.report_interlock(message_event)
+
             await message_event.write_digital_input(digital_input_reset)
             await message_event.write_power_system_state(
                 power_type,
@@ -838,6 +853,8 @@ class MockCommand:
             await asyncio.sleep(self.SLEEP_TIME_NORMAL)
 
             await message_event.write_digital_output(digital_output_default)
+            await self.report_interlock(message_event)
+
             await message_event.write_power_system_state(
                 power_type, power_system.is_power_on(), power_system.state
             )
@@ -995,6 +1012,7 @@ class MockCommand:
             self._digital_output, bit, status
         )
         await message_event.write_digital_output(self._digital_output)
+        await self.report_interlock(message_event)
 
         # Turn on/off the power based on the bit value
         if self._digital_output & DigitalOutput.CommunicationPower.value:

--- a/tests/test_controller_eui.py
+++ b/tests/test_controller_eui.py
@@ -128,7 +128,9 @@ class TestControllerEui(unittest.IsolatedAsyncioTestCase):
             self.assertFalse(controller.is_csc)
 
             await asyncio.sleep(SLEEP_TIME_SHORT)
-            self.assertEqual(controller.controller_state, salobj.State.STANDBY)
+
+            # This fault comes from the simulated disconnection error
+            self.assertEqual(controller.controller_state, salobj.State.FAULT)
 
     async def test_clear_errors(self) -> None:
         async with self.make_server() as server, self.make_controller(


### PR DESCRIPTION
* Add the ``MockCommand.report_interlock()`` to report the interlock event.
* Update the ``MockServer._send_welcome_message()`` to send the lost connection error at welcome message.