### PR TITLE
Use the reversed direction of hardpoint correction.

### DIFF
--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v0.10.7
+-------
+
+* Use the reversed direction of hardpoint correction in ``MockControlClosedLoop`` class.
+
 v0.10.6
 -------
 

--- a/python/lsst/ts/m2com/mock/mock_control_closed_loop.py
+++ b/python/lsst/ts/m2com/mock/mock_control_closed_loop.py
@@ -1152,8 +1152,16 @@ class MockControlClosedLoop:
             force_demanded, force_measured
         )
 
-        self.axial_forces["hardpointCorrection"] = force_hardpoint[:num_axial_actuators]
-        self.tangent_forces["hardpointCorrection"] = force_hardpoint[-NUM_TANGENT_LINK:]
+        # Use the negative sign here as requested by scientist.
+        # This is different from the calculation in ts_mtm2_cell with a
+        # negative sign.
+        # The benefit is to make the understanding of force's details easier.
+        self.axial_forces["hardpointCorrection"] = -force_hardpoint[
+            :num_axial_actuators
+        ]
+        self.tangent_forces["hardpointCorrection"] = -force_hardpoint[
+            -NUM_TANGENT_LINK:
+        ]
 
     def _calc_look_up_forces_temperature(
         self,
@@ -1357,7 +1365,7 @@ class MockControlClosedLoop:
         modified by the amount of "force_per_cycle".
 
         The target is:
-        |force_demanded - force_measured - hardpoints| < force_error
+        |force_demanded + hardpoints - force_measured| < force_error
 
         Parameters
         ----------
@@ -1409,7 +1417,7 @@ class MockControlClosedLoop:
 
             final_force[actuators_in_cycle_no_hardpoint_list] = (
                 force_demanded[actuators_in_cycle_no_hardpoint_list]
-                - force_hardpoint[actuators_in_cycle_no_hardpoint_list]
+                + force_hardpoint[actuators_in_cycle_no_hardpoint_list]
             )
 
             actuators_out_of_cycle = np.where(np.abs(force_error) > force_per_cycle)[0]
@@ -1463,7 +1471,7 @@ class MockControlClosedLoop:
         # directly as a first order assumption. In the real control system,
         # we need to consider a feedback loop to decide the actual value of
         # measured force from the previous loop in hardware controller.
-        force_error = force_demanded - force_hardpoint - force_measured
+        force_error = force_demanded + force_hardpoint - force_measured
 
         # Do not consider the force error in hardpoints.
         # This is the logic in M2 cell LabVIEW code by vendor. Need to figure

--- a/tests/mock/test_mock_control_closed_loop.py
+++ b/tests/mock/test_mock_control_closed_loop.py
@@ -745,7 +745,7 @@ class TestMockControlClosedLoop(unittest.TestCase):
         ] = coef_hardpoint * np.ones(NUM_TANGENT_LINK)
 
     def test_force_dynamics_not_in_position_small(self) -> None:
-        self._prepare_force(5, 1)
+        self._prepare_force(3, 1)
         in_position, final_force = self.control_closed_loop._force_dynamics(0.5, 5)
 
         self.assertFalse(in_position)

--- a/tests/mock/test_mock_model.py
+++ b/tests/mock/test_mock_model.py
@@ -82,7 +82,7 @@ class TestMockModel(unittest.IsolatedAsyncioTestCase):
 
         self.assertAlmostEqual(
             self.model.control_closed_loop.axial_forces["hardpointCorrection"][0],
-            -27.8006293,
+            27.8006293,
         )
 
         self.assertEqual(len(self.model.error_handler.list_code_total), 64)
@@ -100,7 +100,7 @@ class TestMockModel(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(self.model.control_open_loop.inclinometer_angle, 120)
         self.assertAlmostEqual(
             self.model.control_closed_loop.axial_forces["hardpointCorrection"][0],
-            -89.3292369,
+            89.3292369,
         )
 
     def test_is_actuator_force_out_limit_closed_loop(self) -> None:


### PR DESCRIPTION
* Use the reversed direction of hardpoint correction in ``MockControlClosedLoop`` class.