### PR TITLE
Set/get ILC mode with the communication power on.

### DIFF
--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -2,6 +2,12 @@
 Version History
 ===============
 
+v1.5.3
+------
+
+* Add the ``Controller.get_ilc_modes()`` and ``Controller.set_ilc_modes_to_nan()``.
+* Fix the bug of ``MockCommand.get_inner_loop_control_mode()`` and ``MockCommand.set_inner_loop_control_mode()`` that the ILC is related to the communication power instead of the motor power.
+
 v1.5.2
 ------
 

--- a/python/lsst/ts/m2com/mock/mock_command.py
+++ b/python/lsst/ts/m2com/mock/mock_command.py
@@ -888,8 +888,8 @@ class MockCommand:
             Status of command execution.
         """
 
-        # Fail the command if the motor power is not on
-        if not model.power_motor.is_power_on():
+        # Fail the command if the communication power is not on
+        if not model.power_communication.is_power_on():
             return model, CommandStatus.Fail
 
         # Note the addresses are 0-based
@@ -930,8 +930,8 @@ class MockCommand:
             Status of command execution.
         """
 
-        # Fail the command if the motor power is not on
-        if not model.power_motor.is_power_on():
+        # Fail the command if the communication power is not on
+        if not model.power_communication.is_power_on():
             return model, CommandStatus.Fail
 
         # Note the addresses are 0-based

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -416,8 +416,8 @@ class TestController(unittest.IsolatedAsyncioTestCase):
         async with self.make_server() as server, self.make_controller(
             server
         ) as controller:
-            # Turn on the motor power
-            await server.model.power_motor.power_on()
+            # Turn on the communication power
+            await server.model.power_communication.power_on()
 
             # Check the bypassed ILCs
             self.assertEqual(controller.ilc_bypassed, [5])
@@ -448,8 +448,8 @@ class TestController(unittest.IsolatedAsyncioTestCase):
         async with self.make_server() as server, self.make_controller(
             server
         ) as controller:
-            # Turn on the motor power
-            await server.model.power_motor.power_on()
+            # Turn on the communication power
+            await server.model.power_communication.power_on()
 
             # Put all ILCs to Fault state first
             self._change_ilc_mode(server.model, MTM2.InnerLoopControlMode.Fault)
@@ -468,8 +468,8 @@ class TestController(unittest.IsolatedAsyncioTestCase):
         async with self.make_server() as server, self.make_controller(
             server
         ) as controller:
-            # Turn on the motor power
-            await server.model.power_motor.power_on()
+            # Turn on the communication power
+            await server.model.power_communication.power_on()
 
             # Put all ILCs to FirmwareUpdate state first
             self._change_ilc_mode(
@@ -484,8 +484,8 @@ class TestController(unittest.IsolatedAsyncioTestCase):
         async with self.make_server() as server, self.make_controller(
             server
         ) as controller:
-            # Turn on the motor power
-            await server.model.power_motor.power_on()
+            # Turn on the communication power
+            await server.model.power_communication.power_on()
 
             # Put all ILCs to Unknown state first
             self._change_ilc_mode(server.model, MTM2.InnerLoopControlMode.Unknown)


### PR DESCRIPTION
* Add the ``Controller.get_ilc_modes()`` and ``Controller.set_ilc_modes_to_nan()``.
* Fix the bug of ``MockCommand.get_inner_loop_control_mode()`` and ``MockCommand.set_inner_loop_control_mode()`` that the ILC is related to the communication power instead of the motor power.