### PR TITLE
Send the ILC modes in the welcome message.

### DIFF
--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v1.5.7
+------
+
+* Send the ILC modes in the ``MockServer._send_welcome_message()``.
+
 v1.5.6
 ------
 

--- a/python/lsst/ts/m2com/mock/mock_server.py
+++ b/python/lsst/ts/m2com/mock/mock_server.py
@@ -27,6 +27,7 @@ from lsst.ts import tcpip
 from lsst.ts.utils import make_done_future
 from lsst.ts.xml.enums import MTM2
 
+from ..constant import NUM_INNER_LOOP_CONTROLLER
 from ..enum import CommandStatus, LimitSwitchType, MockErrorCode
 from ..utility import cancel_task_and_wait, correct_inclinometer_angle
 from .mock_command import MockCommand
@@ -319,6 +320,12 @@ class MockServer:
         await self._message_event.write_power_system_state(
             MTM2.PowerType.Motor, power_motor.is_power_on(), power_motor.state
         )
+
+        # Send the current ILC modes to be unknown
+        for address in range(NUM_INNER_LOOP_CONTROLLER):
+            await self._message_event.write_inner_loop_control_mode(
+                address, MTM2.InnerLoopControlMode.Unknown
+            )
 
     async def _monitor_and_report_system_status(self) -> None:
         """Monitor the system status and report the specific events."""

--- a/tests/mock/test_mock_server.py
+++ b/tests/mock/test_mock_server.py
@@ -31,6 +31,7 @@ from lsst.ts import tcpip
 from lsst.ts.m2com import (
     DEFAULT_ENABLED_FAULTS_MASK,
     NUM_ACTUATOR,
+    NUM_INNER_LOOP_CONTROLLER,
     NUM_TANGENT_LINK,
     NUM_TEMPERATURE_EXHAUST,
     NUM_TEMPERATURE_INTAKE,
@@ -161,7 +162,7 @@ class TestMockServer(unittest.IsolatedAsyncioTestCase):
             self.assertTrue(server.are_servers_connected())
 
             # Check the one-time message (welcome messages)
-            self.assertGreaterEqual(self.queue_cmd.qsize(), 15)
+            self.assertGreaterEqual(self.queue_cmd.qsize(), 99)
 
             # Check the TCP/IP connection
             msg_tcpip = self.queue_cmd.get_nowait()
@@ -245,6 +246,14 @@ class TestMockServer(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(msg_power_motor["powerType"], MTM2.PowerType.Motor)
             self.assertFalse(msg_power_motor["status"])
             self.assertEqual(msg_power_motor["state"], MTM2.PowerSystemState.Init)
+
+            for address in range(NUM_INNER_LOOP_CONTROLLER):
+                msg_ilc = self.queue_cmd.get_nowait()
+                self.assertEqual(msg_ilc["id"], "innerLoopControlMode")
+                self.assertEqual(msg_ilc["address"], address)
+                self.assertEqual(
+                    msg_ilc["mode"], MTM2.InnerLoopControlMode.Unknown.value
+                )
 
     async def test_monitor_msg_cmd_ack(self) -> None:
         async with self.make_server() as server, self.make_clients(server) as (


### PR DESCRIPTION
* Send the ILC modes in the ``MockServer._send_welcome_message()``.